### PR TITLE
fix syntax-error of package.json

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -4,6 +4,6 @@
   "engines": "0.9.1",
   "author": "Minori Yamashita",
   "dependencies": {
-    "optimist": "0.3.4",
+    "optimist": "0.3.4"
   }
 }


### PR DESCRIPTION
Fix syntax error of `src/package.json`.

Npm cannot parse tailing comma( a.k.a. ケツコンマ).
